### PR TITLE
Fix: avoid duplicate 'card' class on Card component (#80)

### DIFF
--- a/client/src/components/Card/Card.vue
+++ b/client/src/components/Card/Card.vue
@@ -1,15 +1,12 @@
 <template>
 	<div
 		:card-type="cardType"
-		:class="{
-			disabled: isDisabled,
-		}"
+		:class="['btn-card', { disabled: isDisabled }]"
 		:style="cardStyle"
-		class="btn-card"
 		role="button"
 		@click="!isDisabled && onClick(details, matches, $event)"
 	>
-		<span :class="cardClass" class="card">
+		<span :class="['card', cardClass]">
 			<icon v-if="hasMatch" name="sun" class="icon" />
 		</span>
 	</div>
@@ -81,10 +78,12 @@ export default {
 	computed: {
 		cardClass: function() {
 			if (!isEmpty(this.details)) {
+				// return only the variant class (e.g. 'attack--squirrel')
 				return `${this.details.cardType}--${this.details.name}`;
 			}
 
-			return 'blank--';
+			// when there's no detail, don't return a duplicate base class — return empty
+			return '';
 		},
 		hasMatch: function() {
 			return this.matches.length;


### PR DESCRIPTION
Summary
- Prevents the "card" element from receiving duplicate classes (e.g. "card card attack--squirrel") by consolidating class bindings in Card.vue and ensuring the computed cardClass returns only the variant class.

Changes
- Modified: client/src/components/Card/Card.vue
  - Use unified :class bindings on wrapper and span elements
  - cardClass computed now returns only the variant (e.g. "attack--squirrel") or an empty string

Why
- Mixing a static class attribute with a :class binding that can include the same token produced duplicated classes in the rendered DOM. This fix makes class merging predictable and avoids extraneous classes.

Testing
- Start client and inspect DOM:
  - cd client
  - npm install
  - npm run serve
- Verify card elements render like: class="card attack--squirrel" (no duplicate "card")
- Optional: inspect other components for similar patterns

Related
- Fixes issue #80